### PR TITLE
Run job on login

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: objective-c
 osx_image: xcode7.2b1
 before_script:
 - brew update
+- make bootstrap
 - umask 027 # see https://github.com/Homebrew/homebrew/issues/46419
 script:
 - make

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,13 @@ test-unit:
 	plutil -lint /Library/LaunchDaemons/com.cybertk.launchd-oneshot.job.sh.plist
 
 	sudo rm -f /tmp/launchd-oneshot.test
+	sudo rm -f /usr/local/var/log/launchd-oneshot/job.sh.log
 	sudo launchctl load /Library/LaunchDaemons/com.cybertk.launchd-oneshot.job.sh.plist
 	sleep 1
 	[ -f /tmp/launchd-oneshot.test ]
-	[ -f tests/job.sh.done.log ]
+	[ -f /usr/local/var/log/launchd-oneshot/job.sh.log ]
 	[ ! -f /Library/LaunchDaemons/com.cybertk.launchd-oneshot.job.sh.plist ]
+	[ ! -f /usr/local/var/launchd-oneshot/jobs/job.sh ]
 	sudo launchctl list | grep com.cybertk.launchd-oneshot.job.sh.plist || true
 	
 test-homebrew-formula:

--- a/Makefile
+++ b/Makefile
@@ -5,21 +5,7 @@ FORMULA = launchd-oneshot
 test: test-unit test-homebrew-formula
 
 test-unit:
-	sudo ./launchd-oneshot tests/job.sh
-	[ -f /Library/LaunchDaemons/com.cybertk.launchd-oneshot.job.sh.plist ]
-	# test-template:
-	plutil -lint /Library/LaunchDaemons/com.cybertk.launchd-oneshot.job.sh.plist
-
-	sudo rm -f /tmp/launchd-oneshot.test
-	sudo rm -f /usr/local/var/log/launchd-oneshot/job.sh.log
-	sudo launchctl load /Library/LaunchDaemons/com.cybertk.launchd-oneshot.job.sh.plist
-	sleep 1
-	[ -f /tmp/launchd-oneshot.test ]
-	[ -f /usr/local/var/log/launchd-oneshot/job.sh.log ]
-	[ ! -f /Library/LaunchDaemons/com.cybertk.launchd-oneshot.job.sh.plist ]
-	[ ! -f /usr/local/var/launchd-oneshot/jobs/job.sh ]
-	sudo launchctl list | grep com.cybertk.launchd-oneshot.job.sh.plist || true
-	
+	bats tests/cli-test.sh
 test-homebrew-formula:
 	# Setup
 	cp $(FORMULA).rb $(shell brew --repository)/Library/Formula
@@ -29,3 +15,6 @@ test-homebrew-formula:
 	brew reinstall --HEAD $(FORMULA)
 	# brew test $(FORMULA)
 	# brew audit --strict --online $(FORMULA).rb
+
+bootstrap:
+	brew reinstall bats shellcheck

--- a/Makefile
+++ b/Makefile
@@ -17,18 +17,7 @@ test-unit:
 	[ -f tests/job.sh.done.log ]
 	[ ! -f /Library/LaunchDaemons/com.cybertk.launchd-oneshot.job.sh.plist ]
 	sudo launchctl list | grep com.cybertk.launchd-oneshot.job.sh.plist || true
-
-    # Install job as Agents
-	sudo ./launchd-oneshot tests/job.sh --agents
-	[ -f /Library/LaunchAgents/com.cybertk.launchd-oneshot.job.sh.plist ]
-
-	sudo rm -f /tmp/launchd-oneshot.test
-	sudo launchctl load /Library/LaunchAgents/com.cybertk.launchd-oneshot.job.sh.plist
-	sleep 1
-	[ -f /tmp/launchd-oneshot.test ]
-	[ -f tests/job.sh.done.log ]
-	[ ! -f /Library/LaunchAgents/com.cybertk.launchd-oneshot.job.sh.plist ]
-	sudo launchctl list | grep com.cybertk.launchd-oneshot.job.sh.plist || true
+	
 test-homebrew-formula:
 	# Setup
 	cp $(FORMULA).rb $(shell brew --repository)/Library/Formula

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # launchd-oneshot
 
-> Run a oneshot [launchd](http://launchd.info) job at next boot/login time
+> Run a oneshot job at next boot/login time on OSX
 
 [![CI Status](http://img.shields.io/travis/cybertk/launchd-oneshot/master.svg?style=flat)](https://travis-ci.org/cybertk/launchd-oneshot)
 
@@ -9,7 +9,7 @@
 **launchd-oneshot** can be installed via Homebrew
 
 ```bash
-brew install launchd-oneshot
+brew install https://raw.githubusercontent.com/cybertk/launchd-oneshot/master/launchd-oneshot.rb
 ```
 
 ## Getting started
@@ -20,6 +20,12 @@ To add a oneshot job `script.sh` to run at next boot time
 sudo launchd-oneshot script.sh
 ```
 
+To add a oneshot job `script.sh` to run at next user login time
+
+```bash
+sudo launchd-oneshot script.sh --on-login
+```
+
 ## Troubleshooting
 
 logs is written to `/tmp/launchd-oneshot.log`, you can view it with
@@ -27,3 +33,9 @@ logs is written to `/tmp/launchd-oneshot.log`, you can view it with
 ```bash
 tail -f /tmp/launchd-oneshot.log
 ```
+
+## How does launchd-oneshot work?
+
+**launchd-oneshot** installs a **launchd agent** under `/Library/LaunchDaemons` for each job. When agent is running, it will start **launchd-oneshot** in **RUN** mode, which will execute the origin job and remove the **launchd agent** when job is completed.
+
+For `--on-login` job, in order to run the job as root, **launchd-oneshot** will install a trigger **launchd agent** under `/Library/LaunchAgents` in addition. When user login, the trigger agent will start running. And it will trigger the **launchd agent** under `/Library/LaunchDaemons` to run through launchd's `KeepAlive:OtherJobEnabled` mechanism.

--- a/launchd-oneshot
+++ b/launchd-oneshot
@@ -1,9 +1,15 @@
 #!/bin/sh
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+launchd_oneshot_bin=$(/usr/local/bin/realpath "$0")
 
 LOG=/tmp/launchd-oneshot.log
 
+# Parameters
+# - job_id
+# - launchd_oneshot_bin
+# - job
+# - LOG
 # Append `!` to handle `sh -e`
 ! read -d '' TEMPLATE << "EOF"
 <?xml version="1.0" encoding="UTF-8"?>
@@ -46,46 +52,67 @@ render_template()
   eval "echo \"$(echo "$1")\""
 }
 
-job=$1
+run_job()
+{
+    declare job=$1
+    declare job_id=$2
 
-if [ ! -x "$job" ];
-then
-  echo "error: $job is not executable"
-  echo
-  echo "Usage: launchd-oneshot <job>"
-  exit 1
-fi
+    launchd_job="/Library/LaunchDaemons/$job_id.plist"
 
-launchd_oneshot_bin=$(/usr/local/bin/realpath "$0")
-job=$(/usr/local/bin/realpath "$job") # realpath is installed by `brew install coreutils`
-job_id=com.cybertk.launchd-oneshot.$(basename "$job" | tr ' ' '-')
-launchd_job="/Library/LaunchDaemons/$job_id.plist"
+    eval "$job"
+    rc=$?
 
-if [ -n "$LAUNCHD_ONESHOT_JOB" ];
-then
-  # mode: Run job
-  eval "$job"
-  rc=$?
+    if [[ "$rc" -eq 0 ]]; then
+        # Job is complete, cleanup
+        rm -f "$launchd_job"
+        cp "$LOG" "$job.done.log"
+        echo "Job done, archived logs at '$job.done.log'"
+        # `launchctl unload` will kill this process immediately
+        # `launchctl remove` will unload the job
+        launchctl remove "$job_id"
+        echo "Never reached here"
+    fi
 
-  if [ "$rc" -eq 0 ]; then
-    rm -f "$launchd_job"
-    cp "$LOG" "$job.done.log"
-    echo "Job done, archived logs at '$job.done.log'"
-    # `launchctl unload` will kill this process immediately
-    # `launchctl remove` will unload the job
-    launchctl remove "$job_id"
-    echo "Never reached here"
-  fi
-  exit "$rc"
-fi
+    exit "$rc"
+}
 
-# mode: Install job
-if [ "$(id -u)" != "0" ];
-then
-   echo "error: This script must be run as root" 1>&2
-   exit 1
-fi
+install_job()
+{
+    declare job=$1
+    declare job_id=$2
 
-render_template "$TEMPLATE" > "$launchd_job"
-chmod 644 "$launchd_job"
-echo "Installed $1 to $launchd_job"
+    launchd_job="/Library/LaunchDaemons/$job_id.plist"
+
+    if [[ "$(id -u)" != "0" ]]; then
+       echo "error: This script must be run as root" 1>&2
+       exit 1
+    fi
+
+    render_template "$TEMPLATE" > "$launchd_job"
+    chmod 644 "$launchd_job"
+    echo "Installed $1 to $launchd_job"
+}
+
+main()
+{
+    declare job=$1
+
+    job=$(/usr/local/bin/realpath "$job") # realpath is installed by `brew install coreutils`
+    job_id=com.cybertk.launchd-oneshot.$(basename "$job" | tr ' ' '-')
+
+    if [[ ! -x "$job" ]]; then
+        echo "error: $job is not executable"
+        echo
+        echo "Usage: launchd-oneshot <job>"
+        exit 1
+    fi
+
+    if [[ -n "$LAUNCHD_ONESHOT_JOB" ]]; then
+        run_job "$job" "$job_id"
+        exit "$?"
+    fi
+
+    install_job "$job" "$job_id"
+}
+
+main "$@"

--- a/launchd-oneshot
+++ b/launchd-oneshot
@@ -1,15 +1,16 @@
 #!/bin/sh
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+JOBS_DIR=/usr/local/var/launchd-oneshot/jobs
 launchd_oneshot_bin=$(/usr/local/bin/realpath "$0")
 
-LOG=/tmp/launchd-oneshot.log
+LOGS_DIR=/usr/local/var/log/launchd-oneshot
 
 # Parameters
 # - job_id
 # - launchd_oneshot_bin
 # - job
-# - LOG
+# - log
 # Append `!` to handle `sh -e`
 ! read -d '' TEMPLATE << "EOF"
 <?xml version="1.0" encoding="UTF-8"?>
@@ -38,9 +39,9 @@ LOG=/tmp/launchd-oneshot.log
 	    <false/>
 	  </dict>
 		<key>StandardOutPath</key>
-		<string>${LOG}</string>
+		<string>${log}</string>
 		<key>StandardErrorPath</key>
-		<string>${LOG}</string>
+		<string>${log}</string>
 	</dict>
 </plist>
 
@@ -59,14 +60,14 @@ run_job()
 
     launchd_job="/Library/LaunchDaemons/$job_id.plist"
 
-    eval "$job"
+    eval "$JOBS_DIR/$job"
     rc=$?
 
     if [[ "$rc" -eq 0 ]]; then
         # Job is complete, cleanup
         rm -f "$launchd_job"
-        cp "$LOG" "$job.done.log"
-        echo "Job done, archived logs at '$job.done.log'"
+        rm -f "$JOBS_DIR/$job"
+        echo "Job done, log can be found at '$LOGS_DIR/$job.log'"
         # `launchctl unload` will kill this process immediately
         # `launchctl remove` will unload the job
         launchctl remove "$job_id"
@@ -78,19 +79,27 @@ run_job()
 
 install_job()
 {
-    declare job=$1
+    declare job_path=$1
     declare job_id=$2
 
     launchd_job="/Library/LaunchDaemons/$job_id.plist"
+    job=$(basename "$job_path" | tr ' ' '-')
+    log="$LOGS_DIR/$job.log"
 
     if [[ "$(id -u)" != "0" ]]; then
        echo "error: This script must be run as root" 1>&2
        exit 1
     fi
 
+    # Install launchd agents
     render_template "$TEMPLATE" > "$launchd_job"
     chmod 644 "$launchd_job"
-    echo "Installed $1 to $launchd_job"
+
+    # Install jobs to JOBS_DIR
+    cp "$job_path" "$JOBS_DIR/$job"
+
+    echo "Installed launchd agent to $launchd_job"
+    echo "Installed job to $JOBS_DIR/$job"
 }
 
 main()
@@ -100,6 +109,11 @@ main()
     job=$(/usr/local/bin/realpath "$job") # realpath is installed by `brew install coreutils`
     job_id=com.cybertk.launchd-oneshot.$(basename "$job" | tr ' ' '-')
 
+    if [[ -n "$LAUNCHD_ONESHOT_JOB" ]]; then
+        run_job "$job" "$job_id"
+        exit "$?"
+    fi
+
     if [[ ! -x "$job" ]]; then
         echo "error: $job is not executable"
         echo
@@ -107,10 +121,9 @@ main()
         exit 1
     fi
 
-    if [[ -n "$LAUNCHD_ONESHOT_JOB" ]]; then
-        run_job "$job" "$job_id"
-        exit "$?"
-    fi
+    # Ensure jobs dir is exist
+    mkdir -p "$JOBS_DIR" > /dev/null 2>&1
+    mkdir -p "$LOGS_DIR" > /dev/null 2>&1
 
     install_job "$job" "$job_id"
 }

--- a/launchd-oneshot
+++ b/launchd-oneshot
@@ -53,11 +53,17 @@ render_template()
   eval "echo \"$(echo "$1")\""
 }
 
+id_for_job()
+{
+    declare job=$1
+    echo com.cybertk.launchd-oneshot.$job
+}
+
 run_job()
 {
     declare job=$1
-    declare job_id=$2
 
+    job_id=$(id_for_job "$job")
     launchd_job="/Library/LaunchDaemons/$job_id.plist"
 
     eval "$JOBS_DIR/$job"
@@ -80,10 +86,10 @@ run_job()
 install_job()
 {
     declare job_path=$1
-    declare job_id=$2
 
-    launchd_job="/Library/LaunchDaemons/$job_id.plist"
     job=$(basename "$job_path" | tr ' ' '-')
+    job_id=$(id_for_job "$job")
+    launchd_job="/Library/LaunchDaemons/$job_id.plist"
     log="$LOGS_DIR/$job.log"
 
     if [[ "$(id -u)" != "0" ]]; then
@@ -106,13 +112,12 @@ main()
 {
     declare job=$1
 
-    job=$(/usr/local/bin/realpath "$job") # realpath is installed by `brew install coreutils`
-    job_id=com.cybertk.launchd-oneshot.$(basename "$job" | tr ' ' '-')
-
     if [[ -n "$LAUNCHD_ONESHOT_JOB" ]]; then
-        run_job "$job" "$job_id"
+        run_job "$job"
         exit "$?"
     fi
+
+    job=$(/usr/local/bin/realpath "$job") # realpath is installed by `brew install coreutils`
 
     if [[ ! -x "$job" ]]; then
         echo "error: $job is not executable"
@@ -125,7 +130,7 @@ main()
     mkdir -p "$JOBS_DIR" > /dev/null 2>&1
     mkdir -p "$LOGS_DIR" > /dev/null 2>&1
 
-    install_job "$job" "$job_id"
+    install_job "$job"
 }
 
 main "$@"

--- a/launchd-oneshot
+++ b/launchd-oneshot
@@ -23,7 +23,6 @@ LOG=/tmp/launchd-oneshot.log
 		<array>
 			<string>${launchd_oneshot_bin}</string>
 			<string>${job}</string>
-            <string>${job_type}</string>
 		</array>
 		<key>RunAtLoad</key>
 		<true/>
@@ -48,8 +47,6 @@ render_template()
 }
 
 job=$1
-# Daemons vs Agents, default write jobs as deamons
-job_type=${2:-"--daemons"}
 
 if [ ! -x "$job" ];
 then
@@ -62,12 +59,7 @@ fi
 launchd_oneshot_bin=$(/usr/local/bin/realpath "$0")
 job=$(/usr/local/bin/realpath "$job") # realpath is installed by `brew install coreutils`
 job_id=com.cybertk.launchd-oneshot.$(basename "$job" | tr ' ' '-')
-
-if [[ "$job_type" = "--agents" ]]; then
-  launchd_job="/Library/LaunchAgents/$job_id.plist"
-else
-  launchd_job="/Library/LaunchDaemons/$job_id.plist"
-fi
+launchd_job="/Library/LaunchDaemons/$job_id.plist"
 
 if [ -n "$LAUNCHD_ONESHOT_JOB" ];
 then

--- a/launchd-oneshot
+++ b/launchd-oneshot
@@ -1,56 +1,16 @@
 #!/bin/sh
 
+SCRIPT_PATH=$(/usr/local/bin/realpath "$0")
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 JOBS_DIR=/usr/local/var/launchd-oneshot/jobs
-launchd_oneshot_bin=$(/usr/local/bin/realpath "$0")
-
 LOGS_DIR=/usr/local/var/log/launchd-oneshot
 
-# Parameters
-# - job_id
-# - launchd_oneshot_bin
-# - job
-# - log
-# Append `!` to handle `sh -e`
-! read -d '' TEMPLATE << "EOF"
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-	<dict>
-		<key>Label</key>
-		<string>${job_id}</string>
-		<key>EnvironmentVariables</key>
-		<dict>
-			<key>LAUNCHD_ONESHOT_JOB</key>
-			<string>1</string>
-		</dict>
-		<key>Program</key>
-		<string>${launchd_oneshot_bin}</string>
-		<key>ProgramArguments</key>
-		<array>
-			<string>${launchd_oneshot_bin}</string>
-			<string>${job}</string>
-		</array>
-		<key>RunAtLoad</key>
-		<true/>
-		<key>KeepAlive</key>
-		<dict>
-	    <key>SuccessfulExit</key>
-	    <false/>
-	  </dict>
-		<key>StandardOutPath</key>
-		<string>${log}</string>
-		<key>StandardErrorPath</key>
-		<string>${log}</string>
-	</dict>
-</plist>
+PlistBuddy="/usr/libexec/PlistBuddy"
 
-EOF
-
-
-render_template()
+job_for_path()
 {
-  eval "echo \"$(echo "$1")\""
+    declare job_path=$1
+    basename "$job_path" | tr ' ' '-'
 }
 
 id_for_job()
@@ -59,78 +19,174 @@ id_for_job()
     echo com.cybertk.launchd-oneshot.$job
 }
 
+cleanup_job()
+{
+    declare job=$1
+
+    local job_id=$(id_for_job "$job")
+    local launchd_agent="/Library/LaunchDaemons/$job_id.plist"
+
+    rm -f "$JOBS_DIR/$job"
+    rm -f "$launchd_agent"
+    echo "Job done, log can be found at '$LOGS_DIR/$job.log'"
+    # `launchctl unload` will kill this process immediately
+    # `launchctl remove` will unload the job
+    launchctl remove "$job_id"
+}
+
+cleanup_trigger_for_job()
+{
+    declare job_id=$1
+
+    local trigger_job_id=$1.trigger
+    local launchd_agent="/Library/LaunchAgents/$trigger_job_id.plist"
+
+    rm -f "/tmp/$trigger_job_id.options"
+    rm -f "$launchd_agent"
+    launchctl remove "$trigger_job_id"
+}
+
 run_job()
 {
     declare job=$1
 
-    job_id=$(id_for_job "$job")
-    launchd_job="/Library/LaunchDaemons/$job_id.plist"
+    local job_id=$(id_for_job "$job")
+    local launchd_agent="/Library/LaunchDaemons/$job_id.plist"
+    local trigger_options="/tmp/$job_id.trigger.options"
 
-    eval "$JOBS_DIR/$job"
+    # Source job options if exists
+    local run_as=root
+    [[ -f "$trigger_options" ]] && . "$trigger_options"
+
+    su "$run_as" -c "eval '$JOBS_DIR/$job'"
     rc=$?
 
     if [[ "$rc" -eq 0 ]]; then
         # Job is complete, cleanup
-        rm -f "$launchd_job"
-        rm -f "$JOBS_DIR/$job"
-        echo "Job done, log can be found at '$LOGS_DIR/$job.log'"
-        # `launchctl unload` will kill this process immediately
-        # `launchctl remove` will unload the job
-        launchctl remove "$job_id"
+        [[ -f "$trigger_options" ]] && cleanup_trigger_for_job "$job_id"
+        cleanup_job "$job"
         echo "Never reached here"
     fi
 
     exit "$rc"
 }
 
+install_agent_for_job()
+{
+    declare job_path=$1
+    declare should_watch_trigger=$2
+
+    local job=$(job_for_path "$job_path")
+    local job_id=$(id_for_job "$job")
+    local agent_plist="/Library/LaunchDaemons/$job_id.plist"
+    local log="$LOGS_DIR/$job.log"
+
+    # Install launchd agents
+    $PlistBuddy -c 'Add :Label string '"$job_id" "$agent_plist"
+    $PlistBuddy -c 'Add :ProgramArguments array' "$agent_plist"
+    $PlistBuddy -c 'Add :ProgramArguments:0 string '"$SCRIPT_PATH" "$agent_plist"
+    $PlistBuddy -c 'Add :ProgramArguments:1 string '"$job" "$agent_plist"
+    $PlistBuddy -c 'Add :EnvironmentVariables dict' "$agent_plist"
+    $PlistBuddy -c 'Add :EnvironmentVariables:LAUNCHD_ONESHOT_RUN_JOB string 1' "$agent_plist"
+    $PlistBuddy -c 'Add :KeepAlive dict' "$agent_plist"
+    $PlistBuddy -c 'Add :StandardOutPath string '"$log" "$agent_plist"
+    $PlistBuddy -c 'Add :StandardErrorPath string '"$log" "$agent_plist"
+    if [[ -n "$should_watch_trigger" ]]; then
+        watched_job_id="$job_id.trigger"
+        $PlistBuddy -c 'Add :RunAtLoad bool false' "$agent_plist"
+        $PlistBuddy -c 'Add :KeepAlive:OtherJobEnabled dict' "$agent_plist"
+        $PlistBuddy -c 'Add :KeepAlive:OtherJobEnabled:'"${watched_job_id}"' bool true' "$agent_plist"
+        $PlistBuddy -c 'Add :WatchPaths array' "$agent_plist"
+        $PlistBuddy -c 'Add :WatchPaths:0 string '"/tmp/$job_id.trigger.options" "$agent_plist"
+    else
+        $PlistBuddy -c 'Add :KeepAlive:SuccessfulExit bool false' "$agent_plist"
+        $PlistBuddy -c 'Add :RunAtLoad bool true' "$agent_plist"
+    fi
+
+    chmod 644 "$agent_plist"
+
+    # Install jobs to JOBS_DIR
+    cp "$job_path" "$JOBS_DIR/$job"
+
+    echo "Installed launchd agent to $agent_plist"
+    echo "Installed job to $JOBS_DIR/$job"
+}
+
+install_trigger_for_job()
+{
+    declare origin_job_path=$1
+
+    local origin_job=$(job_for_path $origin_job_path)
+    local job=$origin_job.trigger
+    local job_id=$(id_for_job "$job")
+    local agent_plist="/Library/LaunchAgents/$job_id.plist"
+    local log="$LOGS_DIR/$origin_job.log"
+
+    $PlistBuddy -c 'Add :Label string '"$job_id" "$agent_plist"
+    $PlistBuddy -c 'Add :ProgramArguments array' "$agent_plist"
+    $PlistBuddy -c 'Add :ProgramArguments:0 string '"$SCRIPT_PATH" "$agent_plist"
+    $PlistBuddy -c 'Add :ProgramArguments:1 string '"$job" "$agent_plist"
+    $PlistBuddy -c 'Add :EnvironmentVariables dict' "$agent_plist"
+    $PlistBuddy -c 'Add :EnvironmentVariables:LAUNCHD_ONESHOT_RUN_TRIGGER string 1' "$agent_plist"
+    $PlistBuddy -c 'Add :RunAtLoad bool true' "$agent_plist"
+    $PlistBuddy -c 'Add :KeepAlive dict' "$agent_plist"
+    $PlistBuddy -c 'Add :KeepAlive:SuccessfulExit bool false' "$agent_plist"
+    chmod 644 "$agent_plist"
+    echo "Installed trigger to $agent_plist"
+}
+
 install_job()
 {
     declare job_path=$1
+    declare job_type=$2
 
-    job=$(basename "$job_path" | tr ' ' '-')
-    job_id=$(id_for_job "$job")
-    launchd_job="/Library/LaunchDaemons/$job_id.plist"
-    log="$LOGS_DIR/$job.log"
+    job_path=$(/usr/local/bin/realpath "$job_path") # realpath is installed by `brew install coreutils`
+    job_type=${job_type:-"--on-boot"}
+
+    if [[ ! -x "$job_path" ]]; then
+        echo "error: $job_path is not executable"
+        echo
+        echo "Usage: launchd-oneshot /path/to/job [--on-boot | --on-login ]"
+        exit 1
+    fi
 
     if [[ "$(id -u)" != "0" ]]; then
        echo "error: This script must be run as root" 1>&2
        exit 1
     fi
 
-    # Install launchd agents
-    render_template "$TEMPLATE" > "$launchd_job"
-    chmod 644 "$launchd_job"
-
-    # Install jobs to JOBS_DIR
-    cp "$job_path" "$JOBS_DIR/$job"
-
-    echo "Installed launchd agent to $launchd_job"
-    echo "Installed job to $JOBS_DIR/$job"
-}
-
-main()
-{
-    declare job=$1
-
-    if [[ -n "$LAUNCHD_ONESHOT_JOB" ]]; then
-        run_job "$job"
-        exit "$?"
-    fi
-
-    job=$(/usr/local/bin/realpath "$job") # realpath is installed by `brew install coreutils`
-
-    if [[ ! -x "$job" ]]; then
-        echo "error: $job is not executable"
-        echo
-        echo "Usage: launchd-oneshot <job>"
-        exit 1
-    fi
-
     # Ensure jobs dir is exist
     mkdir -p "$JOBS_DIR" > /dev/null 2>&1
     mkdir -p "$LOGS_DIR" > /dev/null 2>&1
 
-    install_job "$job"
+    if [[ "$job_type" = "--on-boot" ]]; then
+        install_agent_for_job "$job_path"
+    elif [[ "$job_type" = "--on-login" ]]; then
+        install_trigger_for_job "$job_path"
+        install_agent_for_job "$job_path" --watch-trigger
+    else
+        echo "unkownn job type: $job_type"
+        exit 1
+    fi
+}
+
+main()
+{
+    declare arg1=$1
+    declare arg2=$2
+
+    # local job_id=com.cybertk.launchd-oneshot.$(basename "$job" | tr ' ' '-')
+
+    if [[ -n "$LAUNCHD_ONESHOT_RUN_TRIGGER" ]]; then
+        local job_options_file=/tmp/$(id_for_job $arg1).options
+        echo "run_as=`id -un`" > "$job_options_file"
+    elif [[ -n "$LAUNCHD_ONESHOT_RUN_JOB" ]]; then
+        run_job "$arg1"
+    else
+        install_job "$arg1" "$arg2"
+    fi
+
+    exit "$?"
 }
 
 main "$@"

--- a/tests/cli-test.sh
+++ b/tests/cli-test.sh
@@ -3,8 +3,10 @@
 fixtures() {
     PATH="$BATS_TEST_DIRNAME/..:$PATH"
     FIXTURE_DIR="$BATS_TEST_DIRNAME/fixtures"
+    SCRIPT_PATH="$(cd "$BATS_TEST_DIRNAME/.." && pwd)/launchd-oneshot"
 
     JOBS_DIR=/usr/local/var/launchd-oneshot/jobs
+    LOGS_DIR=/usr/local/var/log/launchd-oneshot
 }
 
 setup() {
@@ -12,15 +14,14 @@ setup() {
 }
 
 teardown() {
-    launchctl unload /Library/LaunchAgents/com.cybertk.launchd-oneshot.job.sh.trigger.plist
-    sudo launchctl unload /Library/LaunchAgents/com.cybertk.launchd-oneshot.job.sh.trigger.plist
-    sudo launchctl unload /Library/LaunchDaemons/com.cybertk.launchd-oneshot.job.sh.plist
+    launchctl unload /Library/LaunchAgents/com.cybertk.launchd-oneshot.*.plist
+    sudo launchctl unload /Library/LaunchAgents/com.cybertk.launchd-oneshot.*.plist
 
-    sudo rm /Library/LaunchAgents/com.cybertk.launchd-oneshot.job.sh.trigger.plist
-    sudo rm /Library/LaunchDaemons/com.cybertk.launchd-oneshot.job.sh.plist
+    sudo rm /Library/LaunchAgents/com.cybertk.launchd-oneshot.*.plist
+    sudo rm /Library/LaunchDaemons/com.cybertk.launchd-oneshot.*.plist
 
-    sudo rm -f /tmp/launchd-oneshot.test
-    sudo rm -f /usr/local/var/log/launchd-oneshot/job.sh.log
+    sudo rm -f /tmp/launchd-oneshot*
+    sudo rm -f /usr/local/var/log/launchd-oneshot/*
 
     sleep 1
 }
@@ -34,6 +35,7 @@ fixtures
 
 @test "installing a valid job" {
     expected_job=valid.job
+    expected_agent=/Library/LaunchDaemons/com.cybertk.launchd-oneshot.$expected_job.plist
 
     run sudo launchd-oneshot "$FIXTURE_DIR/$expected_job"
     # it should exit 0
@@ -41,12 +43,23 @@ fixtures
     # it should installed job under $JOBS_DIR
     [ -f "$JOBS_DIR/$expected_job" ]
     # it should installed agent under /Library/LaunchDaemons/
-    [ -f /Library/LaunchDaemons/com.cybertk.launchd-oneshot.$expected_job.plist ]
-    plutil -lint /Library/LaunchDaemons/com.cybertk.launchd-oneshot.$expected_job.plist
+    [ -f "$expected_agent" ]
+    plutil -lint "$expected_agent"
+    # it should have correct key/values in agent
+    defaults read "$expected_agent" Label | grep "^com.cybertk.launchd-oneshot.$expected_job$"
+    defaults read "$expected_agent" Program | grep "^$SCRIPT_PATH$"
+    defaults read "$expected_agent" ProgramArguments | wc -l | grep "4"
+    defaults read "$expected_agent" ProgramArguments | grep "$SCRIPT_PATH"
+    defaults read "$expected_agent" ProgramArguments | grep "$expected_job"
+    defaults read "$expected_agent" EnvironmentVariables | grep '"LAUNCHD_ONESHOT_JOB" = 1;'
+    defaults read "$expected_agent" KeepAlive | grep "SuccessfulExit = 0;"
+    defaults read "$expected_agent" RunAtLoad | grep "^1$"
+    defaults read "$expected_agent" StandardErrorPath | grep "^$LOGS_DIR/$expected_job.log$"
+    defaults read "$expected_agent" StandardOutPath | grep "^$LOGS_DIR/$expected_job.log$"
 }
 
 
-@test "when job is complete" {
+@test "load a valid --on-boot job" {
     expected_job=valid.job
     expected_job_signature=/tmp/launchd-oneshot-fixtures.valid.job.signature
     run sudo launchd-oneshot "$FIXTURE_DIR/$expected_job"
@@ -67,6 +80,8 @@ fixtures
 
 @test "installing a valid job with --on-login" {
     expected_job=valid.job
+    expected_agent=/Library/LaunchDaemons/com.cybertk.launchd-oneshot.$expected_job.plist
+    expected_trigger_agent=/Library/LaunchAgents/com.cybertk.launchd-oneshot.$expected_job.trigger.plist
 
     run sudo launchd-oneshot "$FIXTURE_DIR/$expected_job" --on-login
     # it should exit 0
@@ -74,9 +89,32 @@ fixtures
     # it should installed job under $JOBS_DIR
     [ -f "$JOBS_DIR/$expected_job" ]
     # it should installed agent under /Library/LaunchDaemons/
-    [ -f /Library/LaunchDaemons/com.cybertk.launchd-oneshot.$expected_job.plist ]
-    plutil -lint /Library/LaunchDaemons/com.cybertk.launchd-oneshot.$expected_job.plist
+    [ -f "$expected_agent" ]
+    plutil -lint "$expected_agent"
+    # it should have correct key/values in agent
+    defaults read "$expected_agent" Label | grep "^com.cybertk.launchd-oneshot.$expected_job$"
+    defaults read "$expected_agent" Program | grep "^$SCRIPT_PATH$"
+    defaults read "$expected_agent" ProgramArguments | wc -l | grep "4"
+    defaults read "$expected_agent" ProgramArguments | grep "$SCRIPT_PATH"
+    defaults read "$expected_agent" ProgramArguments | grep "$expected_job"
+    defaults read "$expected_agent" WatchPaths | grep "/tmp/com.cybertk.launchd-oneshot.$expected_job.option"
+    defaults read "$expected_agent" EnvironmentVariables | grep '"LAUNCHD_ONESHOT_JOB" = 1;'
+    defaults read "$expected_agent" KeepAlive | grep "SuccessfulExit = 0;"
+    defaults read "$expected_agent" RunAtLoad | grep "^1$"
+    defaults read "$expected_agent" StandardErrorPath | grep "^$LOGS_DIR/$expected_job.log$"
+    defaults read "$expected_agent" StandardOutPath | grep "^$LOGS_DIR/$expected_job.log$"
     # it should installed corresponding trigger agent under /Library/LaunchAgents/
-    [ -f /Library/LaunchAgents/com.cybertk.launchd-oneshot.$expected_job.trigger.plist ]
-    plutil -lint /Library/LaunchAgents/com.cybertk.launchd-oneshot.$expected_job.trigger.plist
+    [ -f "$expected_trigger_agent" ]
+    plutil -lint "$expected_trigger_agent"
+    # it should have correct key/values in trigger agent
+    defaults read "$expected_trigger_agent" Label | grep "^com.cybertk.launchd-oneshot.$expected_job.trigger$"
+    defaults read "$expected_trigger_agent" Program | grep "^$SCRIPT_PATH$"
+    defaults read "$expected_trigger_agent" ProgramArguments | wc -l | grep "4"
+    defaults read "$expected_trigger_agent" ProgramArguments | grep "$SCRIPT_PATH"
+    defaults read "$expected_trigger_agent" ProgramArguments | grep "$expected_job.trigger"
+    defaults read "$expected_trigger_agent" EnvironmentVariables | grep '"LAUNCHD_ONESHOT_JOB" = 1;'
+    defaults read "$expected_trigger_agent" KeepAlive | grep "SuccessfulExit = 0;"
+    defaults read "$expected_trigger_agent" RunAtLoad | grep "^1$"
+    defaults read "$expected_trigger_agent" StandardErrorPath | grep "^$LOGS_DIR/$expected_job.log$"
+    defaults read "$expected_trigger_agent" StandardOutPath | grep "^$LOGS_DIR/$expected_job.log$"
 }

--- a/tests/cli-test.sh
+++ b/tests/cli-test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+fixtures() {
+    PATH="$BATS_TEST_DIRNAME/..:$PATH"
+    FIXTURE_DIR="$BATS_TEST_DIRNAME/fixtures"
+
+    JOBS_DIR=/usr/local/var/launchd-oneshot/jobs
+}
+
+setup() {
+    echo pass
+}
+
+teardown() {
+    launchctl unload /Library/LaunchAgents/com.cybertk.launchd-oneshot.job.sh.trigger.plist
+    sudo launchctl unload /Library/LaunchAgents/com.cybertk.launchd-oneshot.job.sh.trigger.plist
+    sudo launchctl unload /Library/LaunchDaemons/com.cybertk.launchd-oneshot.job.sh.plist
+
+    sudo rm /Library/LaunchAgents/com.cybertk.launchd-oneshot.job.sh.trigger.plist
+    sudo rm /Library/LaunchDaemons/com.cybertk.launchd-oneshot.job.sh.plist
+
+    sudo rm -f /tmp/launchd-oneshot.test
+    sudo rm -f /usr/local/var/log/launchd-oneshot/job.sh.log
+
+    sleep 1
+}
+
+fixtures
+
+# Global setup. See https://github.com/sstephenson/bats/issues/108
+@test "ensure fixtures" {
+    echo pass
+}
+
+@test "installing a valid job" {
+    expected_job=valid.job
+
+    run sudo launchd-oneshot "$FIXTURE_DIR/$expected_job"
+    # it should exit 0
+    [ $status -eq 0 ]
+    # it should installed job under $JOBS_DIR
+    [ -f "$JOBS_DIR/$expected_job" ]
+    # it should installed agent under /Library/LaunchDaemons/
+    [ -f /Library/LaunchDaemons/com.cybertk.launchd-oneshot.$expected_job.plist ]
+    plutil -lint /Library/LaunchDaemons/com.cybertk.launchd-oneshot.$expected_job.plist
+}
+
+
+@test "when job is complete" {
+    expected_job=valid.job
+    expected_job_signature=/tmp/launchd-oneshot-fixtures.valid.job.signature
+    run sudo launchd-oneshot "$FIXTURE_DIR/$expected_job"
+
+    # when job is loaded
+    sudo launchctl load /Library/LaunchDaemons/com.cybertk.launchd-oneshot.$expected_job.plist
+    sleep 1
+
+    # it should run job
+    [ -f "$expected_job_signature" ]
+    # it should generating log of job
+    [ -f /usr/local/var/log/launchd-oneshot/$expected_job.log ]
+    # it should removed agent
+    [ ! -f /Library/LaunchDaemons/com.cybertk.launchd-oneshot.$expected_job.plist ]
+    # it should removed installed job
+    [ ! -f "$JOBS_DIR/$expected_job" ]
+}

--- a/tests/cli-test.sh
+++ b/tests/cli-test.sh
@@ -64,3 +64,19 @@ fixtures
     # it should removed installed job
     [ ! -f "$JOBS_DIR/$expected_job" ]
 }
+
+@test "installing a valid job with --on-login" {
+    expected_job=valid.job
+
+    run sudo launchd-oneshot "$FIXTURE_DIR/$expected_job" --on-login
+    # it should exit 0
+    [ $status -eq 0 ]
+    # it should installed job under $JOBS_DIR
+    [ -f "$JOBS_DIR/$expected_job" ]
+    # it should installed agent under /Library/LaunchDaemons/
+    [ -f /Library/LaunchDaemons/com.cybertk.launchd-oneshot.$expected_job.plist ]
+    plutil -lint /Library/LaunchDaemons/com.cybertk.launchd-oneshot.$expected_job.plist
+    # it should installed corresponding trigger agent under /Library/LaunchAgents/
+    [ -f /Library/LaunchAgents/com.cybertk.launchd-oneshot.$expected_job.trigger.plist ]
+    plutil -lint /Library/LaunchAgents/com.cybertk.launchd-oneshot.$expected_job.trigger.plist
+}

--- a/tests/fixtures/valid.job
+++ b/tests/fixtures/valid.job
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "hello from fixtures/jobs/valid_job"
+touch /tmp/launchd-oneshot-fixtures.valid.job.signature

--- a/tests/fixtures/valid.job
+++ b/tests/fixtures/valid.job
@@ -2,3 +2,4 @@
 
 echo "hello from fixtures/jobs/valid_job"
 touch /tmp/launchd-oneshot-fixtures.valid.job.signature
+touch /tmp/launchd-oneshot-fixtures.valid.job.signature.by.`id -un`

--- a/tests/job.sh
+++ b/tests/job.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-echo "test launchd-oneshot"
-touch /tmp/launchd-oneshot.test


### PR DESCRIPTION
Changes:
- Support run job on user login with `--on-login`
- Re-implement tests with [bats](https://github.com/sstephenson/bats)
- Revert `job_type` implementation
- Improved coding structures with functions
- Generate **launchd agent** plist with `PlistBuddy` instead of using template
- Switching different running mode with environment var, `LAUNCHD_ONESHOT_RUN_JOB` and `LAUNCHD_ONESHOT_RUN_TRIGGER`
